### PR TITLE
Imperative loop/iteraciu

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -82,7 +82,7 @@ block-elsif      aliese
 block-for        porĉiu
 block-given      donite
 block-if         se
-block-loop       iteracio
+block-loop       iteraciu
 block-orwith     aŭkun
 block-repeat     ripetu
 block-unless     kromse


### PR DESCRIPTION
`iteraciu` (loop), imperative form to be consistent with keywords such as `faru` (do) and `provu` (try).

Example in pseudocode: https://eo.wikipedia.org/wiki/Pse%C5%ADdokodo