### PR TITLE
Pragmas and Uses

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -684,7 +684,7 @@ phaser-UNDO      MALFARU
 #pragma-strict              strict
 #pragma-trace               trace
 #pragma-variables           variables
-#pragma-worries             worries
+pragma-worries             zorgojn
 
 # KEY       TRANSLATION
 prefix-not   ne

--- a/EO.l10n
+++ b/EO.l10n
@@ -787,10 +787,10 @@ traitmod-returns   resendas
 typer-subset   subaro
 
 # KEY        TRANSLATION
-use-import    importas
-use-need      bezonas
-#use-no       no
-use-require   postulas
-use-use       uzas
+use-import    importu
+use-need      bezonu
+use-no        forneu
+use-require   postulu
+use-use       uzu
 
 # vim: expandtab shiftwidth=4

--- a/EO.l10n
+++ b/EO.l10n
@@ -679,11 +679,11 @@ phaser-UNDO      MALFARU
 #pragma-MONKEY-SEE-NO-EVAL  MONKEY-SEE-NO-EVAL
 #pragma-MONKEY-TYPING       MONKEY-TYPING
 #pragma-nqp                 nqp
-#pragma-precompilation      precompilation
-#pragma-soft                soft
-#pragma-strict              strict
-#pragma-trace               trace
-#pragma-variables           variables
+pragma-precompilation      antaŭtradukadon
+pragma-soft                molecon
+pragma-strict              striktecon
+pragma-trace               spurantan
+pragma-variables           variablojn
 pragma-worries             zorgojn
 
 # KEY       TRANSLATION


### PR DESCRIPTION
Give `use` keywords use the imperative form.

Modifications to pragma for grammatical reasons:
`molecon`: softness
`striktecon`: strictness/tightness
`spurantan`: tracing

```
forneu zorgojn;
uzu spurantan;
```

Questioning `forneu`; while I believe it captures the action behind it accurately, the word itself is potentially more biblical/archaic. Other candidates to consider:

* `forlasu`
* `neu`