### PR TITLE
Adverb-pc-* and all entries related to keys, values

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -10,7 +10,7 @@
 adverb-pc-delete   for
 adverb-pc-exists   ĉu | chu | cxu
 # Note "k" stands for key
-adverb-pc-k       kie
+adverb-pc-k       kia
 # Note "kv" stands for "key-value (enlisted together)"
 adverb-pc-kv      ane 
 # Note "p" stands for "pair (of index/key and the value of the element)"
@@ -214,8 +214,8 @@ core-isa-ok      isa-bone
 #core-join  join
 
 # KEY      TRANSLATION
-core-key   kie
-core-keys  kies
+core-key   kia
+core-keys  kiaj
 core-kv    ane
 
 # KEY          TRANSLATION
@@ -546,9 +546,9 @@ multi-only    nur
 
 # KEY      TRANSLATION
 # used in grep, without use of named-key alternative form
-named-k    kie
+named-k    kia
 # used in Pair, without use of named-k alternative form
-named-key  kie
+named-key  kia
 # used in grep, without use of named-key-value alternative form
 named-kv   ane
 


### PR DESCRIPTION
Note that *where terseness of the form are a definite trait of the originally translated term*, this PR makes a best effort to provide shortest possible options, provided there are still valid Esperanto word with a pertaining meaning. But it neither shrink down further in scriptural brevity for its own sake, nor resign to longer more precise terms. Both these paths can obviously have their own attractiveness, including easiness of reaching a possible option.

For terms which don’t have such a trait in the original rendition, a more lax approach is used regarding word length, but the standards of idiomatic formulation is kept as high as possible.

# adverb-pc

## adverb-pc-delete

Proposing *for*, preposition [defined as](https://vortaro.net/#for_kd) *malaperon, neniiĝon*. Compare [forigi](https://en.wiktionary.org/wiki/forigi) (to remove).

## adverb-pc-exists

Proposing *[ĉu](https://vortaro.net/#%C4%89u_kd)*, as this article is also used as a [tag question](https://en.wikipedia.org/wiki/Tag_question) and simply express some doubt on whether the underlying (existential) suppositions hold, compare the typical "ĉu vere?".

## adverb-pc-k

Proposing `kie` (where, as in "in which location"), as it’s where the value stands in its container.

## adverb-pc-kv (and other -kv entries)

Proposing `ane` as it’s about enlist the members of the container. Current exact wording of the documentation is `Return both the index/key and the value of the element, in the form of a [List](https://docs.raku.org/type/List)`. And -an- is the affix pertaining to membership. So *ani* is "to be member of", and *ane* is the relative adverb. 

While in programming language membership is more associated with elements of classes, it seems fair to use the same vocabulary here, as class themselves also rely on the mental scheme with a container holding named-content attach to some values.

See also:
- https://eo.wikipedia.org/wiki/ANE
- [varbi](https://reta-vortaro.de/revo/dlg/index-2m.html#varb.0i) (enlist):  iu aniĝu al grupo

## adverb-pc-p

Here *p* stands for pair, as its about returning *both the index/key and the value of the element, in the form of a [Pair](https://docs.raku.org/type/Pair), and silently skip nonexistent elements*.

As [duope](https://reta-vortaro.de/revo/dlg/index-2m.html#du.0ope) means *two by two, in pairs*, it would make total sense here, as much as anything derived from *par/o* (pair). Mainly for the sake of conciseness, the proposal does make the concession of an apherese to *ope*, though it also make sense conceptually. Indeed *[opo](https://komputeko.net/#tuple)* is already used to translate *[tuple](https://en.wikipedia.org/wiki/Tuple)*, which can be defined in terms of nested ordered pairs, so both notion are tightly tied.

Note that -p in adverb-rx-p (position) and named-p (partial) are unrelated.

# Other entries related to notions of key and value

Since both notion of key and value are treated above and are also used in other entries, for the sake of keeping coherence in translation, these other entries are also tracked here. 

## adverb-q-val, adverb-q-v, core-v, core-value, core-values, named-v, named-value

As explain in bellow conversation  in more details value and related terms (v, val, value) might beshortened with -aĵ-, which is about the concrete object related to the syntactic context. And the longer more precise form can retain *valor/o* as base to end up with *valorige* (though *valorigaĵe* would be even more precise).

However since core-* come in three flavors of -v*, the PR can consider a third term. To keep it short *ere* ([elementally](https://en.wiktionary.org/wiki/elementally)) from [-er-](https://reta-vortaro.de/revo/dlg/index-2m.html#er.0) can be a good fit. All the more considering how named-v is defined as *Only return the matched **elements***. That is, the connection between between values and elements to refer to some stored data is already attested in the documentation. An other option to keep a similar lexical analogy that exits between singular value and plural would be to use singular *valorige* and collective *valorigare*.

See also:
- https://vortaro.net/#valorigi_kd
- https://vortaro.net/#a%C4%B5_kd
- https://reta-vortaro.de/revo/dlg/index-2m.html#er.0o

## core-key, core-keys, named-k, named-key

Here too, *k, key, keys* could ask 3 flavour at first glance.

In fact named-k and named-key are used in different context (grep and Pair respectively), so apparently they can’t overlap and conflict in a common lexical scope, but they refer to the same notion transposed in each specific context.

So that likely lower down the needed number of flavor to 2. As `kie` was already proposed for `adverb-pc-k`above, that set some lexical ground that would be nice to come close to. As it’s an adverb, it can’t be inflected to plural form (*kiej* is not a grammatically correct construction).

But using a collective form is an option: *kieare* (literally "where-set-wise"). That’s only one more sign than *keys*. It’s a grammatically correct construct, but not very frequent to say the least (a quick search on the net didn’t allow to find any hit). 

So instead an other approach is to opt for *[kies](https://reta-vortaro.de/revo/dlg/index-2m.html#kies.0)* (literally "whose"). Given that it is a relative pronoun equivalent to "de kiu" or "de kiuj", it’s a perfect fit for the target semantic that can actually retrieve several values, just one or none. Also obviously, while it doesn’t relate to a noun inflection as for key/keys, *kie* and *kies* are both build on the ki- base and are incidently also one terminal character away from each other (the fact that it’s also *s* is even more of a striking happenstance).

Other options would include *de, deloke, deloke·de, disde, ekde, ekede, el, elde, je* which can all be understood as different nuances of "from(-wise)".