### PR TITLE
Terms pertaining to interpertation modulation of quoting constructs

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -38,8 +38,8 @@ adverb-q-words       disvortige
 adverb-q-w           dis
 adverb-q-quotewords  discitige
 adverb-q-ww          cit
-#adverb-q-s           s
-#adverb-q-scalar      scalar
+adverb-q-scalar      skalare
+adverb-q-s           pra
 #adverb-q-v           v
 #adverb-q-val         val
 


### PR DESCRIPTION
# Exposure of reflections guiding the translation proposals

## `array` (and `a`)
For the shortened form of `tabelo`, we can combine -oj (plural nominative) and -e (adverbial form). Also compare way -uj- which can serve as short form for associative array.

Note: `vicaro` was also a possibility for the long form, but was not retained here.

## `backslash` (and `b`)

For the abbreviated form of `dekliveskapsigne`, `sob` ("malsupren") is actually referring to the scriptural form of the backslash, where we supposedly draw it from top left to bottom right, and simultaneously trying to convey a sens like "*under* the  escape sign", see how *sob* is illustrated in PIV with "sob la signoj de la tiraneco!" as a given example.

## `closure` (and `c`)

For `closure`, Komputeko suggests "fermo", but to my mind it’s taking metonymically the result of the action with the tool serving to perform the action (*fermilo*). So a more precise way to describe the intended transformation can be rendered as "fermilige" (ferm·il·ig·e), which can be interpreted as "making by the mean of a tool designed to perform closures". Taking a metonymic approach, "ferme" could be enough. PIV document *pordoferme* by the way. So "fermilige" is more precise/didactic, and "ferme" is shorter. Given there is already a specific shorter form, this lower the pressure to keep it terse, but don’t completely void it. 

For the shortened form, the preposition `laŭ` makes sense along its third PIV definition: "Dependecon de iu cirkonstanco, pro kiu oni agas, aŭ per kies karaktero oni direktas sian agon".

## single and double

These adjectives are referring to the signs (single quote, double quote) that are most frequently used to interpret strings differently. So "single" and "double" here are now explicitly referring to how the interpretation is done.

With "single" quote, there is possibility to use *escaped* character. Thus *eskap/i* is pretty straightforward and obvious to come with. For a terser term, *fuĝi* is possible, and turn into some suffix-free preposition like *fuĝ* would be a possibility (compare *dum/i, sen/i*, though they are formed in reverse direction). An other approach which don’t require to rely on a neologism is to use *ĉe*, as this preposition refer to a notion of proximity, be it spatial, occupational or regarding some aim. So it makes sense, as single quote are close to a literal interpretation but no more completely thus.

With "double" quote, we get embedded expression interpolation. Thus *pol/i* as a straightforward selection (note that *interpoli* and *ektrapoli* do exist, and *poli* encompasses both notions. For the short form, the most obvious options using prepositions would be *laŭ* (according to [interpolation]), *per* (by the mean of [interpolation]) or *trans* (through [interpolation]). As *laŭ* is already retained elsewhere and *trans* is actually longer than pol/i, only *per* remains as relevant choice among these considered options. 

## adverb-q-exec and adverb-q-e

*Execute* to *plenumig/i* is just the usual translation (*rul·(ig)/i* for *run* would also be an option here). And *ek!* is the traditional exclamation for "let’s go".

## adverb-q-function and adverb-q-f

*Function* usually translate to funkcio. `:function` stands for "Interpolate & calls" (functions). Call -> vok/i. Thus *funkci·vok/i*. And "ho" is an usual interjection of invocation (*al·**vok**·ad/o).

## adverb-q-format and adverb-q-o

While [libre-office use *aŭtomate formati*](https://komputeko.net/#auto-format) and the close relative *formo* and *informo* are possible translation of *format* as substantive, [it’s also associated](https://komputeko.net/#format) with very different lexical bases: aranĝo, prezento, strukturigilo. The idea to evokate here is the one also given by *printf*, that is *print formatted*. So a very straight forward translation holding that sense can for example be *(printi) laŭ·form·ig·it/a(n)* (or *laŭformigite·print/i*). Note that PIV mark *formati* as preferably to avoid, and propose *prepari* instead. Following the lane of [format/o](https://reta-vortaro.de/revo/dlg/index-2m.html#format.0o) we can find *fasono (model), formo (shape),  skemo (schema), ŝablono (template)*. And from *formi* (to form/shape) we can find *modeli* (to model) and *modli* (to mould).

Keeping the later allow a connection with the interjection *hot!* (yah!, cry to make a working animal advance or turn) which can be taken metaphorically as an order to compel to some scheme, thus fitting in the mold of some expected profile. 

# adverb-q-hash

[Hash](https://komputeko.net/#hash), also know as [associative array](https://komputeko.net/#associative) and [dictionary](https://komputeko.net/#dictionary), so respectively *haketo/haktabelo, asocieca/ligita/akompana tabelo, vortaro*. 

Also kunaĵo is defined in PIV like "Aro da kunigitaj objektoj", (while [ReVo translate kunigaĵo](https://reta-vortaro.de/revo/dlg/index-2m.html#kun.0igajxo) is an union set), and *kuniĝaro* would also make sense as *kuniĝi* is *to associate*. Moreover [kuniga krampo](https://reta-vortaro.de/revo/art/kramp.html#kramp.kuniga0o) is curly brace, which is the sign pairs often associated with hash structures.

For the shorter term, using -uj- here make sense at its definition is "Objekton, kiu entenas tute en si pli-malpli grandan kvanton da substanco aŭ da objektoj de difinita speco, montrataj de la rad". And at least in some programming language, a hash allow to constraint the types of the keys and values.

## adverb-q-heredoc adverb-q-to

While here-document would rather translate into *ĉi-tiea-dokutmento*, we can come with something a bit more idiomatic through *ĉi·kune*. 

For the short version, *to* could be translated probably more relevantly with *ĝis* in this context, but to avoid the confusion with the *until* control-flow, it will be fine to use *al* which is also actually shorter.

## adverb-q-words, adverb-q-w, adverb-q-quotewords, adverb-q-ww

As they all pertains to [split](https://reta-vortaro.de/revo/dlg/index-2m.html#lim.dis0i) (apartigi, disigi, dislimi) string `List` of strings, it felt more relevant to treat them altogether.

While *disigi* would be a enough to mean "split (along words)", it will be more precise to use *disvortig/i* (see [attestation in IKU publication](https://dvd.ikso.net/faka/scienco/IKU2006.pdf)). And for short, *dis*, taken as an autonomous preposition [admited in PMEG](https://bertilow.com/pmeg/vortfarado/afiksoj/prefiksoj/dis.html#i-gkd), which can be linked to the previous longer adverb seems a fair trade.

For *quotewords* this time we can rely on *[cit/i](https://vortaro.net/#citi_kd)* to construct *discitig/i*. The autonomous *cit* preposition is also [recognized in PMEG](https://bertilow.com/pmeg/skribo_elparolo/skribo/helposignoj.html#i-j5v) as a pre-existing usage (though Bertilow recommends to employ *citaĵo* instead) which can indeed be found in the wild ([example](https://www.liberafolio.org/arkivo/www.liberafolio.org/2008/aktualeo%231356859062500310.html#1356859062500310)).

## adverb-q-scalar and adverb-q-scalar      

Both [ReVo](https://reta-vortaro.de/revo/dlg/index-2m.html#skalar.0o) and [Komputeko](https://komputeko.net/#scalar) propose the straight forward translation *skalaro* for *scalar*.

As scalars are loosely related to the notion of [primitive data type](https://en.wikipedia.org/wiki/Primitive_data_type), the prefix [pra-](https://reta-vortaro.de/revo/dlg/index-2m.html#pra.0) makes total sense here. The adverbial form *prae* doesn’t make any doubt on grammatical correctness, while the autonomous preposition *pra* is not documented as such in consulted lexicographical resources, but attestations are available in the wild ([example](https://www.facebook.com/tejoesperanto/posts/tejo-kaj-tutmondaj-vo%C4%89oj-global-voices-en-esperanto-kunigas-fortojn-por-volontul/10157789397289732/)).

We can also quote:
> en tiu ĉi kategorio oni ŝajne ne entuziasmas pri ekzemple *mal!, *mis!, *pra!, kies signifoj, laŭ mi, estus facile diveneblaj.
— From [Waringhien pri vortoj. "Lingvo kaj vivo" revizitita post pli ol duona jarcento](https://pure.uva.nl/ws/files/2111384/160425_Waringhien_pri_vortoj.pdf)

So, while borderline, *pra* on its own seems to be in the limits of what can be deemed as worth being retained for the sake of scriptural concision without compromising on carrying the relevant meaningfulness. 

# adverb-q-val and adverb-q-v

We don’t treat them here as they are already ongoing propositions in https://github.com/Raku-L10N/EO/pull/10 and https://github.com/Raku-L10N/EO/pull/12.

# Related resources

- https://komputeko.net/#array
- https://reta-vortaro.de/revo/dlg/index-2m.html#sob.0
- https://komputeko.net/#backslash
- https://vortaro.net/#sob_kd
- https://www.mediawiki.org/wiki/User:Psychoslave/generic_glossary/eo#Tipoj
- https://reta-vortaro.de/revo/dlg/index-2m.html#ferm.0i
- https://vortaro.net/#pordoferme_kd
- https://vortaro.net/#la%C5%AD_kd
- https://github.com/Raku-L10N/L10N/blob/main/resources/CONTEXT.md
- https://dev.to/lizmat/moving-printf-formats-forward-1m3p
- https://komputeko.net/#auto-format
- [Diakronio kaj evolu-fazoj de la leksiko kaj de la vort-farado en Esperanto](https://shs.hal.science/halshs-03513441/document)