### PR TITLE
grep -> filtru

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -186,7 +186,7 @@ core-first          unua
 #core-get   get
 #core-getc  getc
 #core-gist  gist
-#core-grep  grep
+core-grep  filtru
 
 # KEY      TRANSLATION
 #core-hash  hash


### PR DESCRIPTION
[grep](https://en.wikipedia.org/wiki/Grep):
> Its name comes from the [ed](https://en.wikipedia.org/wiki/Ed_(text_editor)) command g/re/p (global regular expression search and print).

> In the [Perl](https://en.wikipedia.org/wiki/Perl) programming language, grep is a built-in function that finds elements in a list that satisfy a certain property.[[16]](https://en.wikipedia.org/wiki/Grep#cite_note-16) This [higher-order function](https://en.wikipedia.org/wiki/Higher-order_function) is typically named [filter](https://en.wikipedia.org/wiki/Filter_(higher-order_function)) or where in other languages.

[filter](https://en.wikipedia.org/wiki/Filter_(higher-order_function)):
> a [higher-order function](https://en.wikipedia.org/wiki/Higher-order_function) that processes a [data structure](https://en.wikipedia.org/wiki/Data_structure) (usually a [list](https://en.wikipedia.org/wiki/List_(data_structure))) in some order to produce a new data structure containing exactly those elements of the original data structure for which a given [predicate](https://en.wikipedia.org/wiki/Predicate_(computer_programming)) returns the [Boolean value](https://en.wikipedia.org/wiki/Boolean_value) true.

`filtru`: Imperative form of the act of filtering: https://en.wiktionary.org/wiki/filtri#Verb_2

```
filtru * %% 2, 1..10; # (2,4,6,8,10)
```