### PR TITLE
Map routines

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -148,7 +148,7 @@ core-cmp-ok         kmp-bone
 
 # KEY         TRANSLATION
 #core-decode   decode
-#core-deepmap  deepmap
+core-deepmap   profundmapu
 core-defined   difinita
 #core-diag     diag
 core-die       mortu
@@ -156,7 +156,7 @@ core-dies-ok   mortas-bone
 #core-dir      dir
 core-does-ok   faras-bone
 core-done      farita
-#core-duckmap  duckmap
+core-duckmap   anasmapu
 
 # KEY               TRANSLATION
 #core-elems          elems
@@ -227,7 +227,7 @@ core-lives-ok  vivas-bone
 
 # KEY        TRANSLATION
 #core-make    make
-#core-map     map
+core-map     mapu
 #core-match   match
 #core-max     max
 #core-min     min


### PR DESCRIPTION
Having gone down a mathematics rabbithole, I've opted to propose `mapu` as the term for map.

`ĵetu` may be a better candidate for the `throw` method on Exceptions (along with catch).

Komputada Leksikono states the use of the term `mapo` in mathematics:
https://bertilow.com/div/komputada_leksikono/JX.html#JxETO

I've seen use of both `mapi` and `mapigi`, however the latter looks to be missing from PIV (presumably because `mapi` is already transitive).

https://www.britannica.com/science/mapping
> The mathematical notion of mapping is an abstraction of the process of making a geographical map. It is now considered to be a fundamental notion pervading much of mathematics.