### PR TITLE
adverb-rx-* related terms

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -69,16 +69,17 @@ adverb-rx-sigspace    spacize
 adverb-rx-s           ize
 adverb-rx-samespace   samespace
 adverb-rx-ss          bis
-
 # counting, possibly from x-times
 adverb-rx-x           da
-
-#adverb-rx-nd          nd
-#adverb-rx-nth         nth
-#adverb-rx-rd          rd
-#adverb-rx-st          st
-
-
+# Esperanto use only a single common -a suffix for all ordinals
+# Here -st as in "first" rendered as 1st
+adverb-rx-st          a
+# Here -nd as in "second" rendered as 2nd
+# adverb-rx-nd          a
+# Here -rd as in "third" rendered as 3rd
+# adverb-rx-rd          a
+# Here used as a sort of preposition, although alluding the generic -th suffix
+adverb-rx-nth         ĉe
 
 # KEY           TRANSLATION
 block-default    defaŭlte


### PR DESCRIPTION
# continue, c, pos, p

Both relates to where the regular expression engine should start to investigate the string. 

`continue`, as the term implicitly imply, will pursue even if it initially fail. So while *kontinu/i](https://reta-vortaro.de/revo/dlg/index-2m.html#kontin3.0i)* is the most straight forward, it kind of lack any semantic hint that it’s about setting a starting point — as the term in English, that is. Something closer to the intended meaning is *[komenc/i](https://reta-vortaro.de/revo/dlg/index-2m.html#komenc.0i)*, for which *[ek!](https://vortaro.net/#ek!_kdc)* is a straight forward shortening alternative.

*[pos](https://docs.raku.org/language/regexes#Pos)* (shortened further as *p*) is of course an apocope of `position`. The documentation comment on it as follow:
>unlike :continue, a match anchored with :pos() will fail, instead of attempting to match further down the string:

So a straight forward translation of the term is *[pozici/i](https://reta-vortaro.de/revo/dlg/index-2m.html#pozici.0o)*. For the shorter alternative, several prepositions could make a good fit, including *al, ĉe, de*. ReVo note that *al* conveys the nuance of showing a place toward but without the affirmation it’s actually reached, so that seems a good fit for the hit or fail that the term is striven for. That said *al* will be closer to *to* that is required elsewhere, and we keep `ĉe` for `nth`¹, that leaves `de` as retained approach here.

¹ Note `ĉe` is also proposed with a different semantic in a different context associated to adverb-q-q already in https://github.com/Raku-L10N/EO/pull/11/files

# exhaustive, ex

[Exhaustive](https://docs.raku.org/language/regexes#Exhaustive) (shortened `ex`) asks to find all possible matches of a regex – including overlapping ones. So [elĉerpa serĉo](https://reta-vortaro.de/revo/dlg/index-2m.html#sercx.elcxerpa0o) is the corresponding established translation. Given the meaning, the adverb *[ĉiel](https://reta-vortaro.de/revo/dlg/index-2m.html#cxiel.0)* makes a perfect fit, but [ĉio](https://reta-vortaro.de/revo/dlg/index-2m.html#cxio.0) (all/everything) also makes sense and is within the limit of a three signs that seems empirically to set a significant threshold when it comes to short scriptural forms. While *ĉie* (everywhere) also comes very close, but it might be a bit confusing when combined with index limits to lookup for.


# global, g

[global](https://docs.raku.org/language/regexes#Global) (shortened `g`) search for every non-overlapping match. 

Possible established translations include ĉiea, ĝenerala, [malloka](https://reta-vortaro.de/revo/dlg/index-2m.html#lok.mal0a), totala, tuta (see [komputeko](https://komputeko.net/#global), [Majstro](https://www.majstro.com/Web/Majstro/adict.php?gebrTaal=fra&bronTaal=eng&doelTaal=epo&teVertalen=global)).

An other possibility that makes sense is [plena](https://reta-vortaro.de/revo/dlg/index-2m.html#plen.0a.kompleta) (full/complete), especially as synonym of *saturated*, which brings on the table some notion of filling completely a space, as opposed to explore the full combinatorial possibilities within a space like exhaustive search imply. The prefix [sat-](https://reta-vortaro.de/revo/dlg/index-2m.html#sat.0a) and the suffix [-oz/](https://reta-vortaro.de/revo/dlg/index-2m.html#oz.0) also conduct similar ideas.

Note that [globa](https://reta-vortaro.de/revo/dlg/index-2m.html#glob.0a) and [(tut)monda](https://reta-vortaro.de/revo/dlg/index-2m.html#mond.0a) can translate *global*, but not in a really relevant sense for the considered context.

Thus the retained propositions *plene* and *oze*.

# ignorecase, i, samecase, ii

It’s well established that *case* translate into [uskl/o](https://komputeko.net/#uskl) in such a context.

So established correspondance include 
- case insensitive: usklecoblinda
- case sensitivity: usklecodisting(ec)o
- case match:	uskleca kongruo
- match case:	atenti usklecon

It’s rather straight forward to also translate "ignore case" with "ia ajn uskleco" (whatever-case), that we can shorten a bit to *ajnuskle* — though a more literal translation would render something like *ignori/malobservi usklecon*.

For *same case* using *samuskle* seems very straight forward. It can be shrinked to *sam* as:
- [PIV does use *sam* as autonomous term](https://vortaro.net/#sam_kdc)
- it’s probably the most frequent "same something" that are selected as required option

# ignoremark, m, samemark, mm

> ℹ️ Note, [documentation](https://docs.raku.org/language/regexes#Ignoremark) gives example only diacritic marks (*diakritoj*), it’s not clear if it also pertains to other [Unicode combination](https://en.wikipedia.org/wiki/Combining_character).

[Translations for diacritical mark](https://komputeko.net/#diacritical%20mark) include *kromsigno, diakrita signo*, while *mark* alone can be *distingo, marko, (montr)ilo, signo* ([Majstro](https://www.majstro.com/Web/Majstro/adict.php?gebrTaal=fra&bronTaal=eng&doelTaal=epo&teVertalen=mark)).

Terms like *ia ajn kromsigneca* (whatever-markness-wise)  and *samkromsigneca* (same-markness-wise) should capture the intended meaning — even beyond diacritics alone. And departing from that, we can browse to satellite notions:
- ia ajn -> of some blurry common quality -> -um-
- sam- -> [simila](https://vortaro.net/#simila_kdc) -> tia

Thus the retained proposals *ajnkromsigne/ume* and *samkromsigne/tia*

# sigspace, s, samespace, ss

>Note, *sig* [apparently](https://ohmyraku.github.io/rakudoc/#_grammar_%E4%B8%AD%E7%9A%84%E5%8A%A8%E6%80%81%E5%8F%98%E9%87%8F) stands for *significance* (see also the use of ["non-significant" in some logs](https://fossies.org/linux/rakudo/docs/ChangeLog#l_7493)).

With [Sigspace](https://docs.raku.org/language/regexes#Sigspace) unquoted whitespace may be converted into `<.ws>` subrule calls.

Significant space will literally translate to *[signifa](https://komputeko.net/#significa) [spaceto](https://reta-vortaro.de/revo/dlg/index-2m.html#spac.0eto)*. On its side whitespace is also rendered as [blankspaco](https://komputeko.net/#whitespace). 

There are miscellaneous constructions that Esperanto provides to mark something as mandatory, including [dev·ig/i](https://reta-vortaro.de/revo/dlg/index-2m.html#dev.0igi), [-end/a](https://reta-vortaro.de/revo/dlg/index-2m.html#end.0) , [nepr/a](https://reta-vortaro.de/revo/dlg/index-2m.html#nepr.0a),  [-u](https://reta-vortaro.de/revo/dlg/index-2m.html#u1.0) and [-iz/i](https://vortaro.net/#-iz_kdc). It’s even possible to combine them all: *nepre·spac·iz·end·devig/u* would be a very strong binding obligation of a mandatory order to imperatively spread out. 😅 On its side `sigspace` is far more lax, as it still comes with contextual interpretation. So *spacize* should be far enough, and a vague *ize* seems fair enough for something that implies to "render more or less as is (regarding spaces)*.

On its side *[samespace/ss](https://docs.raku.org/language/regexes#Samespace) substitution modifier implies the :sigspace modifier for the regex, and in addition, copies the whitespace from the matched string to the replacement string. Given that Zamenhof himself used [enspac/i](https://reta-vortaro.de/revo/dlg/index-2m.html#spac.0o), it seems fair to build *samspac/i*. As for the shortened version, [tiel/tiele](https://eo.wikipedia.org/wiki/Tiel!) (*sic*) would make a great option, bar the length which is more than 3 scriptural signs. However [bis](https://vortaro.net/#bis_kdc) pass this criteria and can mean "used to approve of an actor or singer and ask him/her to repeat a brilliant piece". [Revo](https://reta-vortaro.de/revo/dlg/index-2m.html#BL) on it’s side define it as "An exclamation to ask for repetition (i.e. once again! One more time!)" and propose *ree* as an alterantive (again). A bit far more stretched on semantic side, but that kind of make sense on metaphorical level: we want to repeat the elegant spaces as they were just captured. 

So with all that exposed, that leads to
- sigspace/s: spacize/ize
- samespace/ss: samspace/bis

# overlap, ov
[From documentation](https://docs.raku.org/language/regexes#Overlap):

> To get several matches, including overlapping matches, but only one (the longest) from each starting position, specify the :overlap (short :ov) adverb

Revo translate *overlap* as [interkovr/i](https://reta-vortaro.de/revo/dlg/index-2m.html#kovr.inter0i) and [Majstro]([koincidi](https://www.majstro.com/Details-EO/francais/19996)) *koincidi* or *kovri parte*.

Instead an other approach is to build on common ground with the translation option already retained for `exhaustive`, and reuse [ĉerp/i](https://reta-vortaro.de/revo/dlg/index-2m.html#cxerp.0i) (extract) as building block. To mark a more intense search than the default behavior but less thorough than the one marked by el- (completely), the affix [-eg-](https://reta-vortaro.de/revo/dlg/index-2m.html#eg.0) is a perfect match. We can also use it to form the short alternative as an autonomous adverb. 

That thus leads to *ĉerpege/ege*.

# ratchet, r

[ratchet](https://docs.raku.org/language/regexes#Ratchet)/r causes the regex engine to not backtrack.

The term is literally translatable by [kliko](https://eo.wikipedia.org/wiki/Kliko_(mekaniko)).

We could rely more on the linguistic terminology if we want something that is terminologically accurate and say that we want the engine to be strictly [cataphoric](https://en.wikipedia.org/wiki/Cataphora), so something like *[katafore](https://eo.wikipedia.org/wiki/Kataforo)*.

More generically and with more basic vocabulary the fact of not allowing to return back can be rendered in many ways, as already exposed in sigspace’s section. Here are some possible options: [nereen](https://reta-vortaro.de/revo/dlg/index-2m.html#re.0en), [senretro](https://reta-vortaro.de/revo/dlg/index-2m.html#retro.0), [antaŭen](https://reta-vortaro.de/revo/dlg/index-2m.html#antaux.0en)enda, or antaŭize.

Regarding the alternative short form, tapping into interjection there is "klik", if we wanted to carry the original metaphor further. But it’s maybe a bit too vague to make it click (haha 😜) confidently. We can however move to an other analogy, and using the interjection *[paf](https://reta-vortaro.de/revo/dlg/index-2m.html#paf.0)!* (bang!), as once the gun (pafilo) was shot (pafita) there is no way back for the ammunition (pafaĵo).

That thus leads to *antaŭize/paf*.

# Positional_adverbs: rd, nd, nth, st

Here there is 3 suffixes, -st as in "first" rendered as 1st, -nd as in "second" rendered as 2nd and -rd as in "third" rendered as 3rd. Esperanto use only a single common `-a` suffix for naming all ordinals.

The `nth` construction on on its side is used as a sort of preposition, although alluding the generic -th suffix, and in that sense *ĉe* (at) seems a good fit.

# to

The documentation explains: "A convenient way to write a multi-line string literal is by using a heredoc, which lets you choose the delimiter yourself".

The most straight forward translation is `al`, though in this context `ĝis` or more precisely [ĝispost](https://reta-vortaro.de/revo/dlg/index-2m.html#post.gxis0) could also work. 

# x

Here x stands for "counting", probably as a shortened form of [x times](https://english.stackexchange.com/questions/7894/x-times-as-many-as-or-x-times-more-than).

For "counting", several translation option exist, including kiomi, kvantigi and nombri. As an adverb, [kiom](https://reta-vortaro.de/revo/dlg/index-2m.html#kiom.0) would make total sense. But since there is apparently no long-form for this entry, we can skip all these consideration for now.

On the side of short terms that might make a good match, there is the prepozition [da](https://reta-vortaro.de/revo/dlg/index-2m.html#da.0) (quantity of). 