### PR TITLE
Reconsidering block-given, as "given" as many possible transaltion

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -80,7 +80,7 @@ block-default    defaŭlte
 block-else       alie
 block-elsif      aliese
 block-for        por
-block-given      donite
+block-given      konsiderante
 block-if         se
 block-loop       iteraciu
 block-orwith     aŭkun


### PR DESCRIPTION
Indeed, all the follow are legitimate translations:

> Given the situation everything is possible, but let’s not take anything for a given.

Konsiderante la situacion, ĉio eblas, sed ni ne prenu ion ajn por memkomprenebla.

>Furthermore, what was given can’t be taken back.

Krome, tio, kio estis donita, ne povas esti reprenita.

>Given of a problem are always different.

Datumoj de problemo ĉiam estas malsamaj.

> That’s a given of the problem.

Tio estas donitaĵo/kondiĉo de la problemo.

-- 

Majstro provides almost 30 proposals to translate `give` depending on context.  Not all will pertain here though. 

In itself, the current proposition `donite` seems ok. So this PR is just to make sure that if we stick with it, we did so considering other relevant options too, among which we might retain:
- bring to/lead to: [alkonduke](https://reta-vortaro.de/revo/dlg/index-2m.html#konduk.al0i)
- commutate: [komute](https://reta-vortaro.de/revo/dlg/index-2m.html#komut.0i)
- considering: konsiderante
- give rise to: [elkove](https://reta-vortaro.de/revo/art/kov.html#kov.el0i), [okazige](https://reta-vortaro.de/revo/art/okaz.html#okaz.0igi)
- give out (emit): [elige](https://reta-vortaro.de/revo/art/el.html#el.0igi) (maybe a better fit for [yield](https://docs.raku.org/routine/yield) though)
- give out (distribute): [disdone](https://reta-vortaro.de/revo/art/don.html#don.dis0i)
- given: [donitaĵo](https://reta-vortaro.de/revo/dlg/index-2m.html#don.0itajxo)
- lead (allow going to): [irige](https://reta-vortaro.de/revo/dlg/index-2m.html#ir.0igi)
- switch on: (en)[ŝalte](https://reta-vortaro.de/revo/dlg/index-2m.html#sxalt.0i)