### PR TITLE
core-all

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -98,7 +98,7 @@ constraint-where   kie
 
 # KEY                  TRANSLATION
 #core-abs               abs
-#core-all               all
+core-all               ĉiuj
 #core-antipairs         antipairs
 #core-any               any
 #core-append            append


### PR DESCRIPTION
Other possible options:
- ĉie (everywhere)
- ĉion[, kion] (everything[, that])
- trae (all the way through)
