### PR TITLE
core-append

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -101,7 +101,7 @@ constraint-where   kie
 #core-all               all
 #core-antipairs         antipairs
 #core-any               any
-#core-append            append
+core-append            alpendigu
 #core-ast               ast
 #core-atomic-add-fetch  atomic-add-fetch
 #core-atomic-assign     atomic-assign


### PR DESCRIPTION
While this is probably not the most frequent verb in use *[al·pend·ig/i](https://vortaro.net/#alpendigi_kdc)* is the closest literal translation — see [etymology of append](https://en.wiktionary.org/wiki/append).

Other possibilities include:
- aldoni (add)
- alfiksi (attach, affix), or even simply fiksi (fasten)
- alglui (agglutinate)
- aligi (adjoin)
- alkroĉi (hook on, hitch on)
- alligi (tie to, bind to)
- almeti (place, put onto)
- alteni ( to hold on, cling (to); to rivet)
- alvicigi (adjoin to )
- alvostigi (to put at tail)
- najli (nail)
- suplementi (supplement)