### PR TITLE
core-ast

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -102,7 +102,7 @@ constraint-where   kie
 #core-antipairs         antipairs
 #core-any               any
 #core-append            append
-#core-ast               ast
+core-ast               ast
 #core-atomic-add-fetch  atomic-add-fetch
 #core-atomic-assign     atomic-assign
 #core-atomic-dec-fetch  atomic-dec-fetch


### PR DESCRIPTION
[The documentation](https://docs.raku.org/type/Match#routine_make) explicitly links it to the notion of [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree), as it’s often used in grammatical parsing context.

For reference Komputeko proposes *abstrakta sintaksarbo* as translation of the full-length rendition. And *frazo* (literally *phrase, sentence, expression, statement*) could be used to build up a more idiomatic terms. For example *fraz·ec·aro* for a short-spirited one or  *fraz·kun·ec·arbo* for one that is bit more precise¹.

¹ But I never been found of *tree* as a metaphor, all the more as "root" in real plants often are as numerous as branches if not more. [edit: Keeping the metaphor approach, "echo" seems a better fit, as it can have a single identifiable source of emission, resonate in echo chambers (nodes) that transform the input and further forward/bounce the result. Or even something like instead of arbo (tree), sol·pra·mult·id·aro (set with a unique ancestor and a multiplicity of offspring) so **f**raz·**e**ca·**s**ol·pra·mult·id·aro in that case or **FES’** for short. It can even be retrofitted in some Greek-root-compounded English terms like [hen](https://en.wiktionary.org/wiki/%E1%BC%95%CE%BD#Ancient_Greek)·[archæ](https://en.wiktionary.org/wiki/archae-#English)·[poly](https://en.wiktionary.org/wiki/poly-)·[gen](https://en.wiktionary.org/wiki/%CE%B3%CE%AD%CE%BD%CE%B5%CF%83%CE%B9%CF%82#Ancient_Greek)·[ery](https://en.wiktionary.org/wiki/-ery) and thus phras·[ur](https://en.wiktionary.org/wiki/ur-)·henarchæpolygenery or **PUH** for short.]. But hey, is that a wild digression within a footnote of a side note of something not even proposed for merge? Yes! Ok, sorry, take a cookie: 🍪