### PR TITLE
core-atomic-add-fetch

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -103,7 +103,7 @@ constraint-where   kie
 #core-any               any
 #core-append            append
 #core-ast               ast
-#core-atomic-add-fetch  atomic-add-fetch
+core-atomic-add-fetch  atomaldoneŝargu
 #core-atomic-assign     atomic-assign
 #core-atomic-dec-fetch  atomic-dec-fetch
 #core-atomic-fetch      atomic-fetch


### PR DESCRIPTION
Most straight forward word-for-word proposal as is: *atom·aldon·e·ŝarg/i*. See [*atom* entry on Majstro](https://www.majstro.com/Web/Majstro/adict.php?gebrTaal=fra&bronTaal=eng&doelTaal=epo&teVertalen=atomic) and [*fetch* entry on Komputeko](https://komputeko.net/#fetch).

> ℹ️ Note: ŝargi differs from ŝarĝi (burden) and ŝuti (dump [transfer especially over network]). 

[Fetch could also be rendered, depending on context](https://www.majstro.com/Web/Majstro/adict.php?gebrTaal=fra&bronTaal=eng&doelTaal=epo&teVertalen=fetch), by 

- akiri (obtain, get, gain, secure, impetrate)
- [alporti](https://reta-vortaro.de/revo/dlg/index-2m.html#port.al0i) (bring; fetch and carry; retrieve)
- doni (give; administer; grant; impart; provide; confer; allow; spare; afford; invest with; deal; give)
- ekhavi (get, receive)
- elvoki (evoke, to call forth, to elicit)
- [elpeti](https://vortaro.net/#elpeti_kd) (receive/acquire as a result of a request)
- igi (get, cause, make, have, bring)
- holi¹ (summon)
- irpreni (get; pick up; bring)
- mendi (order)
- revenigi (recall; return; take back)
- venigi (send for; get; bring)

¹ But I can’t find any reference to back this lexical entry. In Teskstaro there is only some (mismatching) hits for Holi (the Festival of Colours, Love and Spring). And [hola](https://reta-vortaro.de/revo/art/hola.html) is a [phatic expression](https://en.wikipedia.org/wiki/Phatic_expression). 

Only _alporti_ and _irpreni_ seems really relevant alternative options in this context to my mind.

The closest match I can think of on phonetic level is fet·ŝu·i (to shoe fetally) and fet·ŝov/i (to shove fetally). In both case we could attempt to build some relevant metaphor, but this will probably a bit too far *fetched* (didn’t even attempt to make the joke intentionally, sorry 😆).

Atomic could also be rendered by *firm/a, koher/a, kompakt/a, kontinu/a, integr/a, monolit/a, ne·dis·ig·ebl/a, ne·divid·ebl/a, ne·romp·ebl/a, ne·on/a, sen·on/a, ne·ŝancel·ebl/a, sen·romp/a*, or even a bit more metaphorically *aŭtonom/a, kern/a, mem·star/a, pra/a, primitiv/a, sen·inter·mank/a, sen·per/a, tuj/a, izolat/a* but most likely not *[nuklea](https://reta-vortaro.de/revo/dlg/index-2m.html#nukle.0a)* which is really more linked to nuclear element in physics.