### PR TITLE
core-bag

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -116,7 +116,7 @@ constraint-where   kie
 core-await              atendu
 
 # KEY          TRANSLATION
-#core-bag       bag
+core-bag       sako
 #core-bail-out  bail-out
 core-bless      benu
 


### PR DESCRIPTION
Straight foward translation.

Other options include [taŝo](https://reta-vortaro.de/revo/dlg/index-2m.html#tasx.0o), [pluraro](https://komputeko.net/#bag), (kiom)[ujo](https://www.majstro.com/Web/Majstro/adict.php?gebrTaal=fra&bronTaal=eng&doelTaal=epo&teVertalen=bag), [multaro](https://eo.wikipedia.org/wiki/Multaro), plurfojaro, neordigitopo.