### PR TITLE
core-bail-out

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -117,7 +117,7 @@ core-await              atendu
 
 # KEY          TRANSLATION
 #core-bag       bag
-#core-bail-out  bail-out
+core-bail-out  kaŭciu
 core-bless      benu
 
 # KEY              TRANSLATION


### PR DESCRIPTION
Here [kaŭcii](https://reta-vortaro.de/revo/dlg/index-2m.html#kauxci.0o) makes sense in a "moving out of jail" metaphor (going out of the test block), as an optional message can be left as a word of caution.

Other options include elsalti, [forŝalti](https://reta-vortaro.de/revo/dlg/index-2m.html#sxalt.for0i), kaŭcieliberigi, but words derived from *ĉerpi* will likely not make a good match here.