### PR TITLE
block-whenever

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -88,7 +88,7 @@ block-repeat     ripetu
 block-unless     kromse
 block-until      ĝis
 block-when       kiam
-block-whenever   kiamajn
+block-whenever   ĉiam-ajn | chiam-ajn | cxiam-ajn
 block-while      dum
 block-with       kun
 block-without    sen


### PR DESCRIPTION
While Esperanto is generally very liberal on agglutinative allowance, it’s better to avoid employing constructs with multiple possible analysis: *kiamajn* was obvisously proposed as *kiam ajn*, but could just as well be interpreted as kiama·j·n (plural accusative of the the adjective *kiama*). Thus to avoid ambiguity at the very least opting for *kiam-ajn* (or *ajn-kiam*) would be preferable.

However, investigating a bit further, it appears that in that context *whenever* stands for *every single time that [some event happens]*, rather than *regardless of the time that [some event happens]*. The latter, at least to my understanding is well translated by *kiam ajn*, while the former is closer to *ĉiam ajn*. 

An other possibility would be to use *ĉiufoje* (every time).

# Related resources
- https://vortaro.net/#%C4%89iam_kd
- https://en.wiktionary.org/wiki/whenever
- https://bertilow.com/pmeg/gramatiko/e-vortecaj_vortetoj/ceteraj/ajn.html
- https://www.facebook.com/Japana.Esperanto.Instituto/posts/4528803233896048/