### PR TITLE
value/variable

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -37,7 +37,7 @@ adverb-pc-exists   ekzistas
 #adverb-q-single      single
 #adverb-q-to          to
 #adverb-q-v           v
-#adverb-q-val         val
+adverb-q-val         varo
 #adverb-q-w           w
 #adverb-q-words       words
 #adverb-q-ww          ww
@@ -363,9 +363,9 @@ core-unlike     malsimila
 core-use-ok     uzas-bone
 
 # KEY        TRANSLATION
-#core-val     val
-#core-value   value
-#core-values  values
+core-val     varo
+core-value   variaĵo
+core-values  variaĵoj
 
 # KEY          TRANSLATION
 core-warn       avertu
@@ -627,7 +627,7 @@ multi-only    nur
 
 # KEY          TRANSLATION
 #named-v        v
-#named-value    value
+named-value    variaĵo
 #named-vent-at  vent-at
 #named-ver      ver
 #named-volume   volume
@@ -684,7 +684,7 @@ phaser-UNDO      MALFARU
 #pragma-soft                soft
 #pragma-strict              strict
 #pragma-trace               trace
-#pragma-variables           variables
+pragma-variables           variantoj
 #pragma-worries             worries
 
 # KEY       TRANSLATION


### PR DESCRIPTION
The idea is to have a common scriptural base for these linked notions, which is close to the source terms (v, val, value, values, variable, [variables, var]).

Here are proposed:
- [var/o](https://reta-vortaro.de/revo/dlg/index-2m.html#var.0o) (ware) where `val` is used in the source
- [vari·aĵ/o](https://reta-vortaro.de/revo/dlg/index-2m.html#vari.0a) ([concrete] variant, variation) where `value` is used in the source
- [vari·ant/o·j] (variable) where `variable` is used in the source

> ℹ️ Note that [*varo* and *vari/i* are note etymologically linked](https://konciza-etimologia-vortaro.github.io/#varo), the lexical proximity is just coincidence on which we play here.

> ℹ️ Note: while *variablo* is also common to translate *variable*, *varianto* is a complete lexical duplicate. The word *variabl/o* is synchronously stand-alone, there is no *-abl-* morphe in standard Esperanto. So using vari·ant·o reinforce the semantic relationship between value and variable by using a common base to render both.

So we switch from the words which are usually apocoped val’ and var’ in the source language to the two full word-base var-, vari-. 