### PR TITLE
chr, chrs, ord, ords

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -134,8 +134,8 @@ core-can-ok         povas-bone
 core-chomp         feĉopiku
 core-chop          ĉopu
 #core-chown         chown
-core-chr           sgn | kr | chr
-core-chrs          sgnj | krj | chrs
+core-chr           kr | chr
+core-chrs          krj | chrs
 #core-classify      classify
 #core-close         close
 core-cmp-ok         kmp-bone


### PR DESCRIPTION
# chr[s]
[chr](https://docs.raku.org/type/Int#routine_chr) stands for character, implying "convert the integer interpreted as a  interpreting the integer as a Unicode codepoint number and converting it to the corresponding character.

In Esperanto [karaktro](https://reta-vortaro.de/revo/dlg/index-2m.html#karaktr.0o) is a possible translation, which is [directly transposed from the English *character*](https://konciza-etimologia-vortaro.github.io/#karaktro). The more idiomatic lexical duplicate being *signo*. So the most idiomatic way express the implied transformation should be something like *alsignigi*/ *alsignizi*.

Here to be close to the spirit of the original trigraphic entry which retains only the first consonants, or equivalently apocope its vowel-stripped rendering *chrctr*, the analysis leads to:
- *krktr* thus *kr*
- *sgn*

For the pluralized version, which return a character sequence as a string, simply appending *-j* will stick with the spirit of the original of using the noun plural suffixal mark *-s*. A more precise fully fledged terms could be *alsignviciz/i*, *alsignviciz/i* or *alsignĉeni*.

> ℹ️ Note: we put aside that character is not really the most [precise term for what this method does at Unicode scale](https://stackoverflow.com/questions/27331819/whats-the-difference-between-a-character-a-code-point-a-glyph-and-a-grapheme).

# ord(s)

[ord](https://docs.raku.org/type/Str#routine_ord) stands for *ordinal [number]* (ordonombro, numero) and is the reverse of the previous transformation returning the [codepoint number](https://komputeko.net/#code%20point) (kodono, signkodo, signonumero) of the base characters of the first grapheme in the string.

Esperanto would thus allow to use  *malalsignigi*/ *malalsignizi* to highlight the inverse construct, or any combination from *al-(kodon|ordonombr|signkod|signonumer)(ig|iz)/i*.

But to keep it in the spirit of the original apocope, both *ord* and *ordj* are obvious given all that was already exposed above.

# Note on fallbacks

As for Unix inspired commands, here we keep the original abbreviated terms as-is as possible fallback