### PR TITLE
core-callframe, core-callsame and core-callwith

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -124,6 +124,12 @@ core-bless      benu
 core-callframe     vokframo
 core-callsame      voksame
 core-callwith      vokperu
+core-lastcall      vokĉesu
+core-samewith      voksameperu
+core-nextwith      vokotperu
+core-nextsame      vokotsame
+core-nextcallee    vokotludu
+
 core-can-ok         povas-bone
 #core-cas           cas
 #core-categorize    categorize
@@ -216,7 +222,6 @@ core-isa-ok      isa-bone
 
 # KEY          TRANSLATION
 core-last       lasta
-#core-lastcall  lastcall
 #core-lc        lc
 core-like       simila
 #core-lines     lines
@@ -240,9 +245,6 @@ core-minmax  minmaks
 # KEY            TRANSLATION
 #core-new         new
 #core-next        next
-#core-nextcallee  nextcallee
-#core-nextsame    nextsame
-#core-nextwith    nextwith
 #core-nok         nok
 core-none         neniu
 core-not          ne
@@ -293,7 +295,6 @@ core-reverse     inversigu
 # KEY             TRANSLATION
 #core-samecase     samecase
 #core-samemark     samemark
-#core-samewith     samewith
 core-say           diru
 #core-set          set
 #core-shell        shell


### PR DESCRIPTION
As [callframe](https://docs.raku.org/type/CallFrame) is clearly exposed conceptually as a substantive, the straight forward *vokframo* don’t make much difficulty.

From that first one, we then want to keep -vok- as head of the words also for translations of [callsame](https://docs.raku.org/language/functions#sub_callsame) and [callwith](https://docs.raku.org/language/functions#sub_callwith).

As a verbal derivative form *callsame* (not waiting any parameter) could be probably translated more idiomatically as an adverb like  *memvoke* (compare [memdire](https://reta-vortaro.de/revo/dlg/index-2m.html#dir.mem0e)) or *samvoke* (compare [samokaze](https://vortaro.net/#samokaze_kd)). But since we want to stick as close as possible to the source representation and we just settled to keep vok- at front of the word, *voksame* is what lies ahead. Here using to a volititve would not bring the best match: consider how `my $variable = callsame;` actually fits a translated sentence like `mia variablo devenas samvoke`.

The `callwith` can evoke the term kunvoki (to convoke, convene), but that’s not really the intended meaning here. Instead of *kun-* here, it’s probably a better fit to use [per/i](https://reta-vortaro.de/revo/dlg/index-2m.html#per.0i) (to procure, provide, supply) to build the aimed term. As this time the function does accept parameters, having a volitive inflection of the verb feels more suited. Thus *vokperu*, and we can mentally map assignation statements like such as `my $variable = callwith($something);` to sentences  like "mia variablo iĝe vokperu ion".

For `lastcall` since it’s about to cease the call chain, vokĉesu speaks by itself. 

Every term encompassing a next are rendered with a `vokot-` prefix ("the about to be called thing"). Except for `nextcallee` they reuse the same vocabulary as above for *same* and *with*. And `nextcallee`  is using *ludi* (to play), somehow with the analogy "playing the next music track" in mind. As it returns itself a callable, it was tempting to also expose this fact lexically with something like *vokotlud·ad·iz·il·o* ("the tool provided by the action of playing the about to come callee") but this was resisted for the sake of keeping the term terser. An other option would have been *vokotumi*.
