### PR TITLE
core-cas

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -127,7 +127,7 @@ core-bless      benu
 core-can-ok         povas-bone
 # Compare-And-Swap (CAS)
 # Performs an atomic compare and swap of the native integer value in a target location
-#core-cas           cas
+core-cas           kaz | cas
 #core-categorize    categorize
 #core-ceiling       ceiling
 #core-chars         chars


### PR DESCRIPTION
[cas](https://docs.raku.org/type/atomicint#sub_cas) performs an atomic Compare And Swap (CAS) of the native integer value in location. Note sure why it’s not prefixed atomic (any clue @lizmat?). [The name Compare And Swap is a standard on in CS, see Wikipedia article](https://en.wikipedia.org/wiki/Compare-and-swap).

In isolation:
- compare: kompari
- and: kaj
- swap: permuti/interŝanĝi

So naive transposition would lead to KKP/KKI.

Regarding naive transposition of swap, there is [svapo](https://reta-vortaro.de/revo/dlg/index-2m.html#svop.0o) which is normally pertaining exclusively to the financial specific meaning, but [svapi is already documented as equivalent of swap in Jura Vortaro Angla - Esperanto ](https://www.eventoj.hu/steb/vortaroj/jura_vortaro_jackson_gb-eo.pdf). And since the term exists to render the atomic nature of simultaneously comparing and switch only if the previous value is the same as the criteria one, it’s popping up immediately the prefixes sam-/mem-. So a bit of liberality would permit to use *memsvapi/samsvapi*.

Esperanto words which are close to *cas* include:
* ĉasi (chase after, hunt, seek after, pursue): evoking the idea to chase away some value if it’s our current target
* kasko (helmet): as is swapping face by putting a helmet if the helmet match the considered head size
* kazo (case): as in "if it’s the case that they equal, in that occasion swap"
* kasacii (overturn, quash, vacate): evoking the swap of destiny if the new judgement validate the previous one

English words which start with *cas* include:
* casino (kazino): evoking the casino's roulette wheel, when the target value is matched the destiny swap
* cashponit (kaso): no obvious metaphor found
* cassette (kasedo): no obvious metaphor found
* castrate (kastri): no obvious metaphor found

So given the previous consideration, ***kaz*** as apocope of either *kazo* or *kazino* looks like a relevant option. It can also be retrofitted into whatever acronym might feel relevant such as *Komparopenda Aprobota Zigzago* (zigzag whose agreement will depend on a comparison). 

Anyway the original acronym is kept as a fallback. 