### PR TITLE
core-grep as graplu or grep

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -186,7 +186,7 @@ core-flip          renversu
 #core-get   get
 #core-getc  getc
 #core-gist  gist
-core-grep   grepu
+core-grep   graplu | grep
 
 # KEY      TRANSLATION
 core-hash  haketo


### PR DESCRIPTION
As decided previously, let the Unix commands reachable per the original term. 

As an alternative using a more Esperanto idiomatic term which form is close to the original term, the PR proposes [grapli](https://vortaro.net/#grapli_kd), where a [graplo](https://reta-vortaro.de/revo/dlg/index-2m.html#grapl.0o) is a grapnel, as it means "hook with a grapnel" and the "global regular expression search and print" utility is about hooking string using pattern grapnels.

