### PR TITLE
core-codes

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -139,7 +139,7 @@ core-chop          ĉopu
 #core-classify      classify
 #core-close         close
 core-cmp-ok         kmp-bone
-#core-codes         codes
+core-codes         koderiomo
 core-comb           kombu
 core-combinations   kombinaĵoj
 #core-conj          conj


### PR DESCRIPTION
From [kodero](https://reta-vortaro.de/revo/dlg/index-2m.html#kod.0ero), and -iom-. 

Note that -iomo is note strictly explicitly defined as "quantity of the root suffixed", but compare [kiomo](https://vortaro.net/#kiomo_kd), [iomo](https://vortaro.net/#iomo_kd), [tioma](https://vortaro.net/#tioma_kd). Something build on less blurry foundations would thus be *koderokiomo*, but it’s starting to be a very long term. On the other hand *koderoj* seems misguiding, as one would rather expect then a sequence of code point as a returned value. So meeting each other halfway there is the proposed option *koderiomo*.