### PR TITLE
core-contains

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -143,7 +143,7 @@ core-cmp-ok         kmp-bone
 core-comb           kombu
 core-combinations   kombinaĵoj
 #core-conj          conj
-#core-contains      contains
+core-contains      entenas
 #core-cross         cross
 
 # KEY         TRANSLATION


### PR DESCRIPTION
Given that contains comes from Old french *contenir*, its etymologically closest possible option is indeed *enteni*.

That said on a purely semantic level, it would be just as well relevant to employ *enhavi*.