### PR TITLE
core-deepmap

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -148,7 +148,7 @@ core-combinations   kombinaĵoj
 
 # KEY         TRANSLATION
 #core-decode   decode
-core-deepmap   profundmapu
+core-deepmap   sobmapu
 core-defined   difinita
 #core-diag     diag
 core-die       mortu


### PR DESCRIPTION
Here the original *[deepmap](https://docs.raku.org/type/Any#method_deepmap)* is a metaphor of going down within  intertwined iterable structures. So the term *deep* is most like brought on the table as it’s a handy way to convey the idea of recursion through a terse term. And profunda, while conveying the same metaphor, fails to keep the shortness in. Actually, [rikursi](https://reta-vortaro.de/revo/dlg/index-2m.html#rekursi.0o)mapu is just as long, and [rikur](https://reta-vortaro.de/revo/dlg/index-2m.html#rikur.0o.MAT)mapu is shorter.

But we can use the same metaphor with [sob-](https://reta-vortaro.de/revo/dlg/index-2m.html#sob.0_), short form equivalent of malsupren- (downwards), though in that case it focuses on how it’s going to traverse the graph rather than where this will lead down to terminal nodes. 