### PR TITLE
core-diag

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -150,7 +150,7 @@ core-contains      entenas
 #core-decode   decode
 core-deepmap   profundmapu
 core-defined   difinita
-#core-diag     diag
+core-diag     sensu
 core-die       mortu
 core-dies-ok   mortas-bone
 #core-dir      dir


### PR DESCRIPTION
The obvious translation of *diagnose* would be *diagnozi*. To bring it closer to the terseness of the original, they are several option:
- sensi (to sense), think about it as in perceive, probe, get impression of
- gvati (survey, stalk, spy on)
- vaĉi (watch)

While `vaĉi` would be the shortest, it’s better keep it for translating `watch` itself (not present in this localization file but at least [watch-path](https://docs.raku.org/routine/IO::Notification.watch-path) is a thing. 

Note that no word close to "diag" in form and meaning was found.

Also note that apocope is not very common word derivation process in Esperanto, all the more when the resulting term in never a proper etymon nor matching a single longer term or at least being preponderant in use frequency (for example *aŭto* for *aŭtomobilo*). Compare [Esperanto clippings](https://en.wiktionary.org/wiki/Category:Esperanto_clippings) (83 entries) and [English clippings](https://en.wiktionary.org/wiki/Category:English_clippings) (2 782 entries), though there is a also bias of course regarding interest of authorship, but I didn’t find anything better to assess this quantitatively. Anyway ,n diagnose the morphs are dia·gnose, and other terms starting with *diag* include *diagenezo, diagnostiko, diagnozi, diagonalo, diagramo*.
