### PR TITLE
core-duckmap rendered as kondukmapu

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -156,7 +156,7 @@ core-dies-ok   mortas-bone
 #core-dir      dir
 core-does-ok   faras-bone
 core-done      farita
-core-duckmap   anasmapu
+core-duckmap   kondukmapu
 
 # KEY               TRANSLATION
 #core-elems          elems


### PR DESCRIPTION
The [duckmap](https://docs.raku.org/type/Any#method_duckmap) is certainly named after [duck typing](https://en.wikipedia.org/wiki/Duck_typing), or more generally the *duck test*. 

So "anas·map/i" is the most straightforward equivalent indeed. But [the idiomatic metaphor of duck test doesn’t seem in widespread use in Esperanto](https://www.google.com/search?q=anaso+testo&lr=lang_eo&sca_esv=6b693d07bb019c16&hl=fr&tbs=lr%3Alang_1eo&ei=qfCvaLP3NuTskdUPsNCisQ4&ved=0ahUKEwjz7_GP6qyPAxVkdqQEHTCoKOYQ4dUDCBA&uact=5&oq=anaso+testo&gs_lp=Egxnd3Mtd2l6LXNlcnAiC2FuYXNvIHRlc3RvMgUQIRigATIFECEYoAFI-R1QghBYsRxwAXgAkAEAmAFCoAH6AaoBATW4AQPIAQD4AQGYAgSgAvoBwgIGEAAYBxgewgIIECEYoAEYwwTCAgUQABjvBcICCBAAGIAEGKIEmAMAiAYBkgcBNKAH8Q2yBwE0uAf6AcIHBTMuMy0xyAcQ&sclient=gws-wiz-serp). And *anas* is nothing like *duck* in its form. 

Here *[konduki](https://reta-vortaro.de/revo/dlg/index-2m.html#konduk.0i)* (to run, control, lead, guide, conduct, handle) is semantically relevant for the intended meaning, and include *duk* which is as close as we can hope to get with *duck* — though obviously its incidental that they are close lexical form. 