### PR TITLE
core-emit

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -160,7 +160,7 @@ core-duckmap   anasmapu
 
 # KEY               TRANSLATION
 #core-elems          elems
-#core-emit           emit
+core-emit           emisiu
 #core-encode         encode
 #core-end            end
 #core-ends-with      ends-with


### PR DESCRIPTION
Hardly can we hope for a more trivial case: [emit](https://docs.raku.org/type/independent-routines#sub_emit) -> [emisi/i](https://reta-vortaro.de/revo/dlg/index-2m.html#emisi.0i)

Note: for named-emit-timed I didn’t find any exact match for "emit-timed" in the documentation, so I don’t know what it is referring to. If you have some clue @lizmat, it would be more than welcome. 💗