### PR TITLE
get and set

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -183,7 +183,7 @@ core-floor         planko
 #core-full-barrier  full-barrier
 
 # KEY      TRANSLATION
-#core-get   get
+core-get   gajnu
 #core-getc  getc
 #core-gist  gist
 core-grep   grepu
@@ -295,7 +295,7 @@ core-reverse     inversigu
 #core-samemark     samemark
 #core-samewith     samewith
 core-say           diru
-#core-set          set
+core-set          garnu
 #core-shell        shell
 #core-shift        shift
 #core-sign         sign


### PR DESCRIPTION
While *[get](https://docs.raku.org/type/IO/Handle#routine_get)* can also be translated to akiri, atingi, ekhavi, konkeri, kapti,  kolekti, rikolti, preni, ricevi, rikolti, and more, here we propose to retain gajni mainly to coordinate it with the translation of *set* to [garni](https://reta-vortaro.de/revo/dlg/index-2m.html#garn.0i) (trim, embellish, decorate, adorn, fit out, furnish, equip, complete, stud, fortify, reinforce, strengthen, garnish), so also one letter switch : get/set, gajni/garni.

# See also
- https://komputeko.net/#get