### PR TITLE
index, indices, rindex

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -194,8 +194,8 @@ core-head  kapo
 
 # KEY           TRANSLATION
 #core-indent     indent
-#core-index      index
-#core-indices    indices
+core-index      indekso
+core-indices    indeksoj
 #core-indir      indir
 core-invert     interŝanĝu
 core-is          estas
@@ -281,7 +281,7 @@ core-reduce       reduktu
 core-return       resendu
 #core-return-rw   return-rw
 core-reverse     inversigu
-#core-rindex      rindex
+core-rindex      finindekso
 #core-rmdir       rmdir
 #core-roll        roll
 #core-roots       roots


### PR DESCRIPTION
See [indico](https://reta-vortaro.de/revo/dlg/index-2m.html#indic.0o).

Note the most straight-forward approach to localize r[ight]-index would be *dekstrindico*, but given it’s more about how far we want to be positioned from the beginning of the string — consider right-to-left scripting systems where the start of the rendering is at rightmost displayed part — it’s seems more relevant to opt for *finindico*. All the more as it’s shorter, so closer to the spirit of the compressed *r[ight]* original form. 

> Note that compressing even further in *findico* might be funnier and faithful to original rendering, but maybe a bit too confusing here. 