### PR TITLE
join and join with junt- base

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -207,7 +207,7 @@ core-isa-ok      isa-bone
 #core-item       item
 
 # KEY      TRANSLATION
-#core-join  join
+core-join  juntu
 
 # KEY      TRANSLATION
 #core-key   key
@@ -537,7 +537,7 @@ multi-only    nur
 #named-into        into
 
 # KEY         TRANSLATION
-#named-joiner  joiner
+named-joiner  junto
 
 # KEY      TRANSLATION
 #named-k    k


### PR DESCRIPTION
See [junto](https://vortaro.net/#junto_kdc) and [junti](https://vortaro.net/#junti_kdc).

While *kunig(i|ilo)* is a more frequent translation for join, here using *junt-* does the trick to keep it closer to the original form while still being completely valid on semantic level. 