### PR TITLE
Documenting core-lsb

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -224,7 +224,7 @@ core-like       simila
 #core-list      list
 core-lives-ok  vivas-bone
 # Least Significant Bit -> malplej signifa bito/duumo
-core-lsb        lsb
+core-lsb        mejpezbito | lsb
 
 # KEY        TRANSLATION
 #core-make    make

--- a/EO.l10n
+++ b/EO.l10n
@@ -223,7 +223,8 @@ core-like       simila
 #core-link      link
 #core-list      list
 core-lives-ok  vivas-bone
-#core-lsb       lsb
+# Least Significant Bit -> malplej signifa bito/duumo
+core-lsb        lsb
 
 # KEY        TRANSLATION
 #core-make    make


### PR DESCRIPTION
Just as [*malpli* is sometime transposed *men*](https://www.eventoj.hu/steb/vortaroj/Matematika_vortaro_kaj_oklingva_leksikono-Bavant-2003.pdf), actually [Zamenhof himself proposed it](https://edukado.net/upload/forumo/13023_1430834584.pdf), also [*malplej* is sometime rendered *mej*](https://literatura.bucek.name/pic/pic.htm).

And *[signifa](https://reta-vortaro.de/revo/dlg/index-2m.html#signif.0a)* semantic can be held by *grava* or *peza*. 

As for *bit* it can be rendered either by *[duum[aĵ]o](https://vortaro.net/#duumo_kdc)* or *[bito](https://vortaro.net/#bito_kdc)*.

Thus we can select any combination among them, and notably: 
- *mej peza bito* for the shortest, which can even be shrinked into *mejpezbito*, that is MPB in initialism. 
- *malplej signifa duumaĵo* for the longest, that is MSD in initialism.

The acronyms are there just for the sake of showing they were not left unthought, but proposing them as an option doesn’t seem to be a move aligned with our precedent decisions.

The PR thus propose *mejpezbito* with a fallback on the original `lsb`.

# References
- https://komputeko.net/#signific
- https://manuals.plus/eo/seneca/t201dch50-mu-acdc-true-rms-or-dc-bipolar-current-transformer-manual
- https://reta-vortaro.de/revo/dlg/index-2m.html#plej.mal0
- https://archive.org/details/PriReformojEnEsperanto1894/page/n17/mode/2up?q=brev
- http://bonalingvo.net/index.php/Simplaj_samsignifaj_vortoj
- http://luisguillermo.com/PAG/Plena_Analiza_Gramatiko_(K._Kalocsay,_G._Waringhien).pdf
- https://www.esperanto-bjelovar.hr/kresko0518.pdf