### PR TITLE
core-make as igu

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -227,7 +227,7 @@ core-lives-ok  vivas-bone
 #core-lsb       lsb
 
 # KEY         TRANSLATION
-core-make     fasonu
+core-make     igu
 core-map      mapu
 #core-match   match
 core-max      maks


### PR DESCRIPTION
In the frame of https://github.com/Raku-L10N/EO/issues/82 this one seems consensual as-is by now. 

Note that I don’t see any entry for "made", possibly this is not part of the basis facilities of Raku.