### PR TITLE
uncomment core-match

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -229,7 +229,7 @@ core-lives-ok  vivas-bone
 # KEY         TRANSLATION
 core-make     fasonu
 core-map      mapu
-#core-match   match
+core-match   match
 core-max      maks
 core-min      min
 core-minmax   minmaks


### PR DESCRIPTION
The straight forward translation for *to match* is *[kongru(ig)i](https://reta-vortaro.de/revo/dlg/index-2m.html#kongru.0i)*.

On form level the naive transliteration *matĉ* only holds for [matĉo/maĉo](https://reta-vortaro.de/revo/dlg/index-2m.html#macx1.0o) (a match in sport, that is a fight, bet between individuals or teams in any sporting game).

Given that [mat](https://reta-vortaro.de/revo/dlg/index-2m.html#mat1.0) is a valid word on its own, in that is checkmate in chess (ŝako), it’s possible to use it as prefix to mean "finding a winning/matching path/pattern/set-of-moves). Then we can lookup for a short verb starting with *ŝ-*:
- ŝaki (to chess) to pursue the metaphor to its term
- ŝipi (to navigate, sail, cruise, ship)
- ŝosi (to sprout)
- ŝovi (to shove, thrust, put carefully)
- ŝoti (to shoot a goal)
- ŝuti (to poor, to dump data)

I like how *ŝoti* also overlap with sport metaphor, just as the original *match*. So *matŝoti* would be the resulting elected term.

What’s your thoughts on this @m-dango, @ccmywish ? 