### PR TITLE
(anti)pair(s)

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -99,7 +99,7 @@ constraint-where   kie
 # KEY                  TRANSLATION
 core-abs               abs
 core-all               ĉiuj
-#core-antipairs         antipairs
+core-antipairs         antiparoj
 core-any               ajn
 core-append            alpendigu
 #core-ast               ast
@@ -257,8 +257,8 @@ core-open   malfermu
 #core-ords  ords
 
 # KEY              TRANSLATION
-#core-pair          pair
-#core-pairs         pairs
+core-pair          paro
+core-pairs         paroj
 #core-parse-base    parse-base
 core-pass           pasigu
 core-permutations   permutaĵoj


### PR DESCRIPTION
All are very straight forward to my mind, see [anti-](https://vortaro.net/#anti-_kdc) and [paro](https://vortaro.net/#paro_kdc) for PIV related material.

#12 might be closed @m-dango if we move forward with this one.

Note that [*Antiparo* is also the name of an island](https://eo.wikipedia.org/wiki/Listo_de_insuloj_en_la_Mediteraneo) but I doubt it's an issue here.