### PR TITLE
core-parse-base

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -259,7 +259,7 @@ core-open   malfermu
 # KEY              TRANSLATION
 #core-pair          pair
 #core-pairs         pairs
-#core-parse-base    parse-base
+core-parse-base    parse-base
 core-pass           pasigu
 core-permutations   permutaĵoj
 #core-pick          pick


### PR DESCRIPTION
Given it's doing the reverse of [base](https://docs.raku.org/routine/base), *malbazi* seems the obvious goto, see [bazo](https://reta-vortaro.de/revo/dlg/index-2o.html#baz.0o). Other prefixes than [mal-](https://reta-vortaro.de/revo/dlg/index-2o.html#mal.0) could be considered in that case, including de-, el-, kontraŭ- and invers[a]-

Regarding the *[parse](https://komputeko.net/#parse)* part in the original term, I'm not sure it worth borrow it in the localization, but if we want to move in that direction, here are some options:
- [analizi](https://reta-vortaro.de/revo/dlg/index-2o.html#analiz.0ilo)
- derivi
- disaranĝi
- disponigi

But if parse is there mostly to highlight the possibility that the operation might fail if the provided argument is not a relevant fit for the parser, we might simply use -um-, so *malbazum/i*. 