### PR TITLE
core-pop

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -264,7 +264,7 @@ core-pass           pasigu
 core-permutations   permutaĵoj
 #core-pick          pick
 core-plan           planas
-core-pop           pop
+core-pop           elmetu
 #core-prepend       prepend
 core-print          printu
 core-printf         printfu

--- a/EO.l10n
+++ b/EO.l10n
@@ -264,7 +264,7 @@ core-pass           pasigu
 core-permutations   permutaĵoj
 #core-pick          pick
 core-plan           planas
-core-pop           elmetu
+core-pop           elstakigu
 #core-prepend       prepend
 core-print          printu
 core-printf         printfu

--- a/EO.l10n
+++ b/EO.l10n
@@ -264,7 +264,7 @@ core-pass           pasigu
 core-permutations   permutaĵoj
 #core-pick          pick
 core-plan           planas
-#core-pop           pop
+core-pop           pop
 #core-prepend       prepend
 core-print          printu
 core-printf         printfu


### PR DESCRIPTION
Possible options include:
- [eligi](https://reta-vortaro.de/revo/art/el.html#el.0igi) (emit, give forth(emit, produce), give off (emit, vent), give out (emit), let off(emit), let out(emit, release), throw off(emit))
- ekstrakti (extract)
- elirigi (deprive ; dismiss)
- elĵeti (throw out)
- ellogi (draw out, elicit)
- elmeti (put out, put forth)
- eltiri (withdraw, extract)
- eltrovi (find, unearth)
- elkapti (capture)
- elklapi (pop out)
- ellasi (release ; unleash ; draw) 
- elpreni (take out)
- [elstakigi](https://reta-vortaro.de/revo/dlg/index-2o.html#stak.0o) (pop)
- elŝpruĉi (spout)
- preni (take)
- [krevi](https://reta-vortaro.de/revo/art/krev.html#krev.0i) (burst, crack)
- ŝpruci (gush ; spurt ; spurt out ; spout ; spray ; sprinkle ; gush out ; shoot forth)
- viziteti (drop in, pop in)

So at first glance in that context *eligi* and *elĵeti* seem the best fits. Indeed in that case the  `pop` method operate on an array. Obviously, a stack can be implemented as an array, so *el_stak_igi* is not incompatible, but a bit orthogonal. So using the most frequent correspondence (array/tabelo) we would employ *eltabeligi* or *eltabeloĵeti*.

Probably *eligi* is missing a bit the meaning that the process remove, and not only *produce out of* (somehow like *emit*). And given ĵeti is also proposed for kubĵeti in #44, maybe we want to avoid to employ it here. 

While *preni* is probably a better fit for core-take, and *elpreni* for core-take-rw.

All that considered, *elmeti* looks like the best remaining option. 

# Related resources
- https://komputeko.net/#pop
- https://www.majstro.com/Web/Majstro/adict.php?gebrTaal=fra&bronTaal=eng&doelTaal=epo&teVertalen=pop
- https://vortaro.jp/v?q=elklapi
- https://vortaro.jp/v?q=similaj%20al:%20eskludi
- https://komputeko.net/Komputeko2012.pdf