### PR TITLE
-pend familly

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -265,7 +265,7 @@ core-permutations   permutaĵoj
 #core-pick          pick
 core-plan           planas
 #core-pop           pop
-#core-prepend       prepend
+core-prepend       elpendigu
 core-print          printu
 core-printf         printfu
 #core-proceed       proceed
@@ -462,7 +462,7 @@ multi-only    nur
 #named-absolute  absolute
 #named-actions   actions
 #named-api       api
-#named-append    append
+named-append    alpendiga
 #named-arg0      arg0
 #named-args      args
 #named-as        as


### PR DESCRIPTION
While _prependi_ would be closer on the form, [*pre-* is not an official prefix](https://bertilow.com/pmeg/vortfarado/neoficialaj_afiksoj/prefiksoj/pre.html) though words like *prefaco* makes it a borderline synchronous regular affix in my opinion. Anyway, *[elpendi](https://vortaro.net/#elpendi_kdc)* is documented, as well as *elpendaĵo*, and it's closer to *alpendigi* that we already retained for *append*.

As a named parameter, *append* is a boolean, so an adjective looks like a better fit. 