### PR TITLE
core-push as almeti

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -270,7 +270,7 @@ core-print          printu
 core-printf         printfu
 #core-proceed       proceed
 #core-prompt        prompt
-#core-push          push
+core-push          almetu
 #core-put           put
 
 # KEY            TRANSLATION


### PR DESCRIPTION
Coordinate with proposal in #91 as it's somehow the reverse operation. 

Note that here *push* is rather standing for *push back* which would then straight forwardly translate to *[postenigi](https://reta-vortaro.de/revo/dlg/index-2o.html#post.0enigi)*.

By itself *puŝi* (shove, jog) is not a great fit at semantic level, though *[enpuŝi](https://reta-vortaro.de/revo/dlg/index-2o.html#pusx.en0i)* or [posten](https://reta-vortaro.de/revo/dlg/index-2o.html#post.0en)puŝi might do the trick.

But since we have *pop* proposed as *elmeti*, it's just very obvious that *almeti* would be a great fit here.