### PR TITLE
core-proceed

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -268,7 +268,7 @@ core-plan           planas
 #core-prepend       prepend
 core-print          printu
 core-printf         printfu
-#core-proceed       proceed
+core-proceed       avancu
 #core-prompt        prompt
 #core-push          push
 #core-put           put


### PR DESCRIPTION
Here [proceed](https://docs.raku.org/language/control#proceed_and_succeed) is in the sens *go ahead*, so not translatable as 

An option for "go straight ahead" is [antaŭiri](https://reta-vortaro.de/revo/dlg/index-2o.html#ir.antaux0i), which is synonym with *avanci* in the sense *move ahead, progress*.