### PR TITLE
core-put

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -271,7 +271,7 @@ core-printf         printfu
 #core-proceed       proceed
 #core-prompt        prompt
 #core-push          push
-core-put           eĥu | ehhu | ehxu
+core-put           metu
 
 # KEY            TRANSLATION
 #core-rand        rand

--- a/EO.l10n
+++ b/EO.l10n
@@ -271,7 +271,7 @@ core-printf         printfu
 #core-proceed       proceed
 #core-prompt        prompt
 #core-push          push
-#core-put           put
+core-put           eĥu | ehhu | ehxu
 
 # KEY            TRANSLATION
 #core-rand        rand


### PR DESCRIPTION
As [put](https://docs.raku.org/type/independent-routines#sub_prompt) is almost like *print*, using *presi* could be an option, or something like _printumi_.

To translate *put* itself, *eligi, loki, meti, eldiri, esprimi, kuŝigi* are all valid options.

Here though the PR propose to employ *eĥi*, as the word *echo* is already pretty common (bash/PHP) for this, and its on par with *put* in term of length.