### PR TITLE
core-rand

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -274,7 +274,7 @@ core-proceed       avancu
 core-put           metu
 
 # KEY            TRANSLATION
-#core-rand        rand
+core-rand        hazardigu
 core-redo         refaru
 core-reduce       reduktu
 #core-repeated    repeated


### PR DESCRIPTION
See https://reta-vortaro.de/revo/dlg/index-2o.html#hazard.0igi for this one which is trivial.

Note that [loti](https://reta-vortaro.de/revo/dlg/index-2o.html?q=loti) was [already retained for core-pick](https://github.com/Raku-L10N/EO/pull/44/files).