### PR TITLE
core-repl

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -278,7 +278,7 @@ core-put           metu
 core-redo         refaru
 core-reduce       reduktu
 #core-repeated    repeated
-#core-repl        repl
+core-repl        repl
 core-return       resendu
 #core-return-rw   return-rw
 core-reverse     inversigu


### PR DESCRIPTION
Since it's named after the acronym for [read–evaluate–print loop](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) (REPL) it's not straight forward to come with a translation in that case.

The abbreviated term is already translated as follow in existing material  
- lego-rulo-preso-bukla ([runtime en espéranto - Anglais-Espéranto dictionnaire | Glosbe](https://glosbe.com/en/eo/runtime)) which would end up with LRPB as acronym
- simply taken as REPL ([Ĉu la Python-interpretilo estas necesa por skribi Python-programojn? - Akademio EITCA](https://eo.eitca.org/komputila-programado/eitc-cp-ppf-python-programaj-fundamentoj/enkonduko-eitc-cp-ppf-python-programado-baza%C4%B5oj/enkonduko-al-programado-de-python-3/estas-la-python-interpretilo-necesa-por-skribi-python-programojn/))

An other ad hoc translation possibility would be *legi-taksi-presi-a ciklo/iteracio/ripetado *

# Related resources
- https://course.raku.org/eo/essentials/running-programs/from-repl/